### PR TITLE
Allow merging of coverage data in python3 as well as python2.

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+import codecs
 import json
 import logging
 import os
@@ -70,8 +71,9 @@ class Coveralls(object):
             return {}
 
     def merge(self, path):
+        reader = codecs.getreader("utf-8")
         with open(path, 'rb') as fh:
-            extra = json.load(fh)
+            extra = json.load(reader(fh))
             self.create_data(extra)
 
     def wear(self, dry_run=False):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -174,9 +174,10 @@ class WearTest(unittest.TestCase):
 
     def test_merge(self, mock_requests):
         api = Coveralls(repo_token='xxx')
-        with patch('json.load') as mock_load:
-            mock_load.return_value = {'source_files': [{'name': 'foobar', 'coverage': []}]}
-            api.merge(__file__)
+        coverage_file = tempfile.NamedTemporaryFile()
+        coverage_file.write(b'{"source_files": [{"name": "foobar", "coverage": []}]}')
+        coverage_file.seek(0)
+        api.merge(coverage_file.name)
         result = api.create_report()
         assert json.loads(result)['source_files'] == [{'name': 'foobar', 'coverage': []}]
 


### PR DESCRIPTION
Allow merging of coverage data in python3 as well as python2. (Fixed failure to load json coverage file in python3.)

This fixes issue #56 