### PR TITLE
Allow debug and output options to work without repo_token.

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -24,7 +24,7 @@ class Coveralls(object):
     api_endpoint = 'https://coveralls.io/api/v1/jobs'
     default_client = 'coveralls-python'
 
-    def __init__(self, **kwargs):
+    def __init__(self, token_required=True, **kwargs):
         """ Coveralls!
 
         * repo_token
@@ -57,7 +57,7 @@ class Coveralls(object):
         if os.environ.get('COVERALLS_REPO_TOKEN', None):
             self.config['repo_token'] = os.environ.get('COVERALLS_REPO_TOKEN')
 
-        if not self.config.get('repo_token') and not is_travis:
+        if token_required and not self.config.get('repo_token') and not is_travis:
             raise CoverallsException('You have to provide either repo_token in %s, or launch via Travis' % self.config_filename)
 
     def load_config(self):

--- a/coveralls/cli.py
+++ b/coveralls/cli.py
@@ -45,7 +45,8 @@ def main(argv=None):
     log.setLevel(level)
 
     try:
-        coverallz = Coveralls(config_file=options['--rcfile'])
+        token_required = not options['debug'] and not options['--output']
+        coverallz = Coveralls(token_required, config_file=options['--rcfile'])
         if options['--merge']:
             coverallz.merge(options['--merge'])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,6 +20,14 @@ def test_debug(mock_wear, mock_log):
 
 @patch.object(coveralls.cli.log, 'info')
 @patch.object(coveralls.Coveralls, 'wear')
+def test_debug_no_token(mock_wear, mock_log):
+    coveralls.cli.main(argv=['debug'])
+    mock_wear.assert_called_with(dry_run=True)
+    mock_log.assert_has_calls([call("Testing coveralls-python...")])
+
+
+@patch.object(coveralls.cli.log, 'info')
+@patch.object(coveralls.Coveralls, 'wear')
 @patch.dict(os.environ, {'TRAVIS': 'True'}, clear=True)
 def test_real(mock_wear, mock_log):
     coveralls.cli.main(argv=[])
@@ -31,7 +39,7 @@ def test_real(mock_wear, mock_log):
 @patch('coveralls.cli.Coveralls')
 def test_rcfile(mock_coveralls):
     coveralls.cli.main(argv=['--rcfile=coveragerc'])
-    mock_coveralls.assert_called_with(config_file='coveragerc')
+    mock_coveralls.assert_called_with(True, config_file='coveragerc')
 
 exc = CoverallsException('bad stuff happened')
 
@@ -47,6 +55,14 @@ def test_exception(mock_coveralls, mock_log):
 @patch.dict(os.environ, {'TRAVIS': 'True'}, clear=True)
 def test_save_report_to_file(mock_coveralls):
     """Check save_report api usage."""
+
+    coveralls.cli.main(argv=['--output=test.log'])
+    mock_coveralls.assert_called_with('test.log')
+
+
+@patch.object(coveralls.Coveralls, 'save_report')
+def test_save_report_to_file_no_token(mock_coveralls):
+    """Check save_report api usage when token is not set."""
 
     coveralls.cli.main(argv=['--output=test.log'])
     mock_coveralls.assert_called_with('test.log')


### PR DESCRIPTION
Allow debug and output options to work without repo_token, as it is not needed for these options.
Fixes #45 