### PR TITLE
Added more explanation around merging.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,11 +84,17 @@ Multiple languages (experimental)
 Tracking multi-language repo coverage requires extra setup of merging coverage data for submission.
 If you already have json file from coveralls library from another language (example from `coveralls-lcov`_)::
 
-    # coveralls-lcov example
+    # Generate data with lcov
     lcov --compat-libtool --directory . --capture --output-file coverage.info
+
+    # Or: generate data with mocha
+    mocha --reporter mocha-lcov-reporter */tests/static/js/* > coverage.info
+
+    # Convert data with coveralls-lcov
     coveralls-lcov -v -n coverage.info > coverage.json
 
-    # merges python coverage with coveralls-style json file and sends it to api endpoint
+    # Merge python coverage with coveralls-style json file and send it to api endpoint
+    # Note: This file must contain "source_files" data or it will not be merged
     coveralls --merge=coverage.json
 
 If you'd like to just use json data from coveralls (with other tools)::

--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -151,6 +151,8 @@ class Coveralls(object):
             self._data.update(self.config)
             if extra and 'source_files' in extra:
                 self._data['source_files'].extend(extra['source_files'])
+            else:
+                log.warn('No data to be merged; does the json file contain "source_files" data?')
         return self._data
 
     def get_coverage(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -205,6 +205,18 @@ class WearTest(unittest.TestCase):
         result = api.create_report()
         assert json.loads(result)['source_files'] == [{'name': 'foobar', 'coverage': []}]
 
+    @patch.object(log, 'warn')
+    def test_merge_invalid_data(self, mock_logger, mock_requests):
+        api = Coveralls(repo_token='xxx')
+        coverage_file = tempfile.NamedTemporaryFile()
+        coverage_file.write(b'{}')
+        coverage_file.seek(0)
+        api.merge(coverage_file.name)
+        result = api.create_report()
+        assert json.loads(result)['source_files'] == []
+        mock_logger.assert_called_once_with('No data to be merged; does the '
+                                            'json file contain "source_files" data?')
+
     def test_dry_run(self, mock_requests):
         self.setup_mock(mock_requests)
         result = Coveralls(repo_token='xxx').wear(dry_run=True)


### PR DESCRIPTION
I had a bit of difficulty figuring out how to use mocha with coveralls. Mocha has its own JSON output, but it is not compatible with coveralls and so the merge silently failed. I had to debug to figure out what was going on. I've added a mocha example to the documentation about merging in external data, and a warning log message if data cannot be merged, so hopefully others will find this painless in future.