### PR TITLE
Make coveralls work with released versions of coverage packages

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -149,10 +149,11 @@ class Coveralls(object):
             self._data = {'source_files': self.get_coverage()}
             self._data.update(self.git_info())
             self._data.update(self.config)
-            if extra and 'source_files' in extra:
-                self._data['source_files'].extend(extra['source_files'])
-            else:
-                log.warn('No data to be merged; does the json file contain "source_files" data?')
+            if extra:
+                if 'source_files' in extra:
+                    self._data['source_files'].extend(extra['source_files'])
+                else:
+                    log.warn('No data to be merged; does the json file contain "source_files" data?')
         return self._data
 
     def get_coverage(self):

--- a/coveralls/reporter.py
+++ b/coveralls/reporter.py
@@ -54,8 +54,8 @@ class CoverallReporter(Reporter):
 
     def parse_file(self, cu, analysis):
         """ Generate data for single file """
-        filename = cu.file_locator.relative_filename(cu.filename)
         if hasattr(analysis, 'parser'):
+            filename = cu.file_locator.relative_filename(cu.filename)
             source_lines = analysis.parser.lines
             with cu.source_file() as source_file:
                 source = source_file.read()
@@ -69,6 +69,7 @@ class CoverallReporter(Reporter):
                          'Please check if encoding declaration is ok', basename(cu.filename))
                 return
         else:
+            filename = analysis.coverage.file_locator.relative_filename(cu.filename)
             source_lines = list(enumerate(analysis.file_reporter.source_token_lines()))
             source = analysis.file_reporter.source()
         coverage_lines = [self.get_hits(i, analysis) for i in range(1, len(source_lines) + 1)]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -205,11 +205,20 @@ class WearTest(unittest.TestCase):
         result = api.create_report()
         assert json.loads(result)['source_files'] == [{'name': 'foobar', 'coverage': []}]
 
+    def test_merge_empty_data(self, mock_requests):
+        api = Coveralls(repo_token='xxx')
+        coverage_file = tempfile.NamedTemporaryFile()
+        coverage_file.write(b'{}')
+        coverage_file.seek(0)
+        api.merge(coverage_file.name)
+        result = api.create_report()
+        assert json.loads(result)['source_files'] == []
+
     @patch.object(log, 'warn')
     def test_merge_invalid_data(self, mock_logger, mock_requests):
         api = Coveralls(repo_token='xxx')
         coverage_file = tempfile.NamedTemporaryFile()
-        coverage_file.write(b'{}')
+        coverage_file.write(b'{"random": "stuff"}')
         coverage_file.seek(0)
         api.merge(coverage_file.name)
         result = api.create_report()


### PR DESCRIPTION
Make coveralls work with released versions of coverage and django-coverage-plugin. Right now, it only works with the tip of my github repo for django-coverage-plugin, which is not ideal. With the released versions of coverage, django-coverage-plugin, and coveralls, you get:
```
Traceback (most recent call last):
  File "/Users/jessamyn/.virtualenvs/eggtimer/bin/coveralls", line 11, in <module>
    sys.exit(main())
  File "/Users/jessamyn/.virtualenvs/eggtimer/lib/python3.4/site-packages/coveralls/cli.py", line 55, in main
    coverallz.wear(dry_run=True)
  File "/Users/jessamyn/.virtualenvs/eggtimer/lib/python3.4/site-packages/coveralls/api.py", line 82, in wear
    json_string = self.create_report()
  File "/Users/jessamyn/.virtualenvs/eggtimer/lib/python3.4/site-packages/coveralls/api.py", line 101, in create_report
    data = self.create_data()
  File "/Users/jessamyn/.virtualenvs/eggtimer/lib/python3.4/site-packages/coveralls/api.py", line 149, in create_data
    self._data = {'source_files': self.get_coverage()}
  File "/Users/jessamyn/.virtualenvs/eggtimer/lib/python3.4/site-packages/coveralls/api.py", line 163, in get_coverage
    return reporter.report()
  File "/Users/jessamyn/.virtualenvs/eggtimer/lib/python3.4/site-packages/coveralls/reporter.py", line 28, in report
    self.parse_file(cu, self.coverage._analyze(cu))
  File "/Users/jessamyn/.virtualenvs/eggtimer/lib/python3.4/site-packages/coveralls/reporter.py", line 57, in parse_file
    filename = cu.file_locator.relative_filename(cu.filename)
AttributeError: 'FileReporter' object has no attribute 'file_locator'
```

Also removed erroneous warning message when writing output to a file:
```
$ coveralls --output=op.txt
Write coverage report to file...
No data to be merged; does the json file contain "source_files" data?
```

Once you are happy with these changes, it would probably be good to release a new alpha so people can get up and running with all released packages. Cheers!