### PR TITLE
Pull branch from Codeship environment

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -194,7 +194,7 @@ class Coveralls(object):
                 'committer_email': gitlog('%ce'),
                 'message': gitlog('%s'),
             },
-            'branch': os.environ.get('CIRCLE_BRANCH') or os.environ.get('TRAVIS_BRANCH', rev),
+            'branch': os.environ.get('CIRCLE_BRANCH') or os.environ.get('CI_BRANCH') or os.environ.get('TRAVIS_BRANCH', rev),
             #origin	git@github.com:coagulant/coveralls-python.git (fetch)
             'remotes': [{'name': line.split()[0], 'url': line.split()[1]}
                         for line in run_command('git', 'remote', '-v').splitlines() if '(fetch)' in line]


### PR DESCRIPTION
Right now Codeship builds just go onto the HEAD branch, which isn't super useful. This should pull the branch of Codeship builds so that they're appropriately marked in Coveralls. [Reference](https://codeship.com/documentation/continuous-integration/set-environment-variables/#default-environment-variables)