### PR TITLE
Return an exit status if coveralls fails

### DIFF
--- a/coveralls/cli.py
+++ b/coveralls/cli.py
@@ -28,6 +28,7 @@ Example:
     https://coveralls.io/jobs/92059
 """
 import logging
+import sys
 from docopt import docopt
 from coveralls import Coveralls
 from coveralls.api import CoverallsException
@@ -67,7 +68,9 @@ def main(argv=None):
         log.info('Aborted')
     except CoverallsException as e:
         log.error(e)
+        sys.exit(1)
     except KeyError as e:  # pragma: no cover
         log.error(e)
+        sys.exit(2)
     except Exception:  # pragma: no cover
         raise

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 import os
+import sys
 
 from mock import patch, call
 import pytest
@@ -47,7 +48,11 @@ exc = CoverallsException('bad stuff happened')
 @patch.object(coveralls.Coveralls, 'wear', side_effect=exc)
 @patch.dict(os.environ, {'TRAVIS': 'True'}, clear=True)
 def test_exception(mock_coveralls, mock_log):
-    coveralls.cli.main(argv=[])
+    try:
+        coveralls.cli.main(argv=[])
+        assert 0 == 1  # Should never reach this line
+    except SystemExit:
+        pass
     mock_log.assert_has_calls([call(exc)])
 
 


### PR DESCRIPTION
I am using coveralls in a build script, and I'd like to know if any step fails. If coveralls returns a non-zero exit status in case of failure, then all works as expected.