### PR TITLE
Added integration with CircleCI and service_pull_request 

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -47,18 +47,25 @@ class Coveralls(object):
             self.config['repo_token'] = repo_token
 
         if os.environ.get('TRAVIS'):
-            is_travis = True
+            is_travis_or_circle = True
             self.config['service_name'] = file_config.get('service_name', None) or 'travis-ci'
             self.config['service_job_id'] = os.environ.get('TRAVIS_JOB_ID')
+        elif os.environ.get('CI'):
+            is_travis_or_circle = True
+            self.config['service_name'] = file_config.get('service_name', None) or 'circle-ci'
+            self.config['service_job_id'] = os.environ.get('CIRCLE_BUILD_NUM')
+            if os.environ.get('CI_PULL_REQUEST', None):
+                self.config['service_pull_request'] = os.environ.get('CI_PULL_REQUEST').split('/')[-1]
         else:
-            is_travis = False
+            is_travis_or_circle = False
             self.config['service_name'] = file_config.get('service_name') or self.default_client
 
         if os.environ.get('COVERALLS_REPO_TOKEN', None):
             self.config['repo_token'] = os.environ.get('COVERALLS_REPO_TOKEN')
 
-        if token_required and not self.config.get('repo_token') and not is_travis:
-            raise CoverallsException('You have to provide either repo_token in %s, or launch via Travis' % self.config_filename)
+        if token_required and not self.config.get('repo_token') and not is_travis_or_circle:
+            raise CoverallsException('You have to provide either repo_token in %s, or launch via Travis or CircleCI'
+                                     % self.config_filename)
 
     def load_config(self):
         try:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -82,7 +82,8 @@ class NoConfig(unittest.TestCase):
         with pytest.raises(Exception) as excinfo:
             Coveralls()
 
-        assert str(excinfo.value) == 'You have to provide either repo_token in .coveralls.mock, or launch via Travis'
+        assert str(excinfo.value) == 'You have to provide either repo_token in .coveralls.mock, or launch via Travis ' \
+                                     'or CircleCI'
 
 
 class Git(GitBasedTest):


### PR DESCRIPTION
Adde some CircleCI specific integration plus support for pull request comments.
API post parameter service_pull_request is the associated pull request ID of the build. It is used for updating the status and/or commenting.