### PR TITLE
Use `--rdir=<dir>` as base point for relative pathes

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -170,6 +170,8 @@ class Coveralls(object):
             workman._harvest_data()
         else:
             workman.get_data()
+        if self.config['rel_dir'] is not None:
+            coverage.files.RELATIVE_DIR = self.config['rel_dir']
         reporter = CoverallReporter(workman, workman.config)
         return reporter.report()
 

--- a/coveralls/cli.py
+++ b/coveralls/cli.py
@@ -17,6 +17,7 @@ Global options:
     --rcfile=<file>   Specify configuration file. [default: .coveragerc]
     --output=<file>   Write report to file.  Doesn't send anything.
     --merge=<file>    Merge report from file when submitting.
+    --rdir=<dir>      Set relative dir, 'r' could also stand for 'root' or 'reference'
     -h --help         Display this help
     -v --verbose      Print extra info, True for debug command
 
@@ -47,7 +48,8 @@ def main(argv=None):
 
     try:
         token_required = not options['debug'] and not options['--output']
-        coverallz = Coveralls(token_required, config_file=options['--rcfile'])
+        coverallz = Coveralls(token_required, config_file=options['--rcfile'],
+                              rel_dir=options['--rdir'])
         if options['--merge']:
             coverallz.merge(options['--merge'])
 


### PR DESCRIPTION
Adds a command argument that allows to set a custom directory as the base point for output pathes.

I opened this PR although the patch at this time only works for coverage 4 - in the hope that you may provide me with some answers so I can make it work for older supported versions too:

- I noticed that there are multiple code branches in `CoverallReporter.parse_file` - for different versions of coveralls, I assume. It would be awesome if there were annotations as to which versions of coverage these code branches are intended for - but since there are none, I thought I'd just ask here first before digging all too deep in commit histories
- which versions of coverage are currently supported?
- what do you think about just dropping support for older versions of coverage?


The reason that I'd like to have this feature is that it greatly simplifies dealing with scenarios where the code is not tested in the git checkout directory but for example in an installation directory. This is useful when one not only wants to test whether the code in the git repository is correct, but also test the package created by setup.py in the same run (did I forget to include any relevant files?).