### PR TITLE
Improve support for AppVeyor CI

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -56,6 +56,12 @@ class Coveralls(object):
             self.config['service_job_id'] = os.environ.get('CIRCLE_BUILD_NUM')
             if os.environ.get('CI_PULL_REQUEST', None):
                 self.config['service_pull_request'] = os.environ.get('CI_PULL_REQUEST').split('/')[-1]
+        elif os.environ.get('APPVEYOR'):
+            is_travis_or_circle = False
+            self.config['service_name'] = file_config.get('service_name', None) or 'appveyor'
+            if os.environ.get('APPVEYOR_REPO_BRANCH'):
+                # Enable Coveralls.git_info() to report the proper branch name.
+                os.environ['CI_BRANCH'] = os.environ['APPVEYOR_REPO_BRANCH']
         else:
             is_travis_or_circle = False
             self.config['service_name'] = file_config.get('service_name') or self.default_client

--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -59,9 +59,9 @@ class Coveralls(object):
         elif os.environ.get('APPVEYOR'):
             is_travis_or_circle = False
             self.config['service_name'] = file_config.get('service_name', None) or 'appveyor'
-            if os.environ.get('APPVEYOR_REPO_BRANCH'):
-                # Enable Coveralls.git_info() to report the proper branch name.
-                os.environ['CI_BRANCH'] = os.environ['APPVEYOR_REPO_BRANCH']
+            self.config['service_job_id'] = os.environ.get('APPVEYOR_BUILD_ID')
+            if os.environ.get('APPVEYOR_PULL_REQUEST_NUMBER'):
+                self.config['service_pull_request'] = os.environ['APPVEYOR_PULL_REQUEST_NUMBER']
         else:
             is_travis_or_circle = False
             self.config['service_name'] = file_config.get('service_name') or self.default_client
@@ -210,7 +210,10 @@ class Coveralls(object):
                 'committer_email': gitlog('%ce'),
                 'message': gitlog('%s'),
             },
-            'branch': os.environ.get('CIRCLE_BRANCH') or os.environ.get('CI_BRANCH') or os.environ.get('TRAVIS_BRANCH', rev),
+            'branch': (os.environ.get('CIRCLE_BRANCH') or
+                       os.environ.get('APPVEYOR_REPO_BRANCH') or
+                       os.environ.get('CI_BRANCH') or
+                       os.environ.get('TRAVIS_BRANCH', rev)),
             #origin	git@github.com:coagulant/coveralls-python.git (fetch)
             'remotes': [{'name': line.split()[0], 'url': line.split()[1]}
                         for line in run_command('git', 'remote', '-v').splitlines() if '(fetch)' in line]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -94,6 +94,15 @@ class NoConfig(unittest.TestCase):
         assert cover.config['service_job_id'] == '888'
         assert cover.config['service_pull_request'] == '9999'
 
+    @patch.dict(os.environ, {'APPVEYOR': 'True',
+                             'APPVEYOR_BUILD_ID': '1234567',
+                             'APPVEYOR_PULL_REQUEST_NUMBER': '1234'}, clear=True)
+    def test_appveyor_no_config(self):
+        cover = Coveralls(repo_token='xxx')
+        assert cover.config['service_name'] == 'appveyor'
+        assert cover.config['service_job_id'] == '1234567'
+        assert cover.config['service_pull_request'] == '1234'
+
 
 class Git(GitBasedTest):
 


### PR DESCRIPTION
Recently I added Windows support, AppVeyor CI tests and coverage collection on Windows to a project of mine (see paylogic/pip-accel#61). In the process I found that support for AppVeyor in *coveralls-python* was a bit tricky to get right.

The `$CI_BRANCH` environment variable isn't available on AppVeyor and the `git rev-parse --abbrev-ref HEAD` fallback in *coveralls-python* incorrectly resulted in `HEAD` which meant my coverage reports on Coveralls.io referenced the branch name `HEAD` instead of the expected value `master` (kind of confusing because `HEAD` isn't a branch AFAIK :-).

During experimentation I worked around this by [creating a wrapper](https://github.com/paylogic/pip-accel/blob/9b4d0186886c0585a7357665933908adfad9f1d5/scripts/appveyor-coverage.py) for the `coveralls` command that would set `$CI_BRANCH` based on `$APPVEYOR_REPO_BRANCH` which resulted in correct behavior. However this implies that every user of *coveralls-python* would need to do this, so I decided to fork and extend *coveralls-python* instead, hopefully saving future users some time and frustration.

My additions follow the "examples" given by the existing Travis and Circle CI support, this is how I decided what the values of `service_job_id` and `service_pull_request` should be (cross-referencing with the [documented environment variables](http://www.appveyor.com/docs/environment-variables) for AppVeyor).

I added a test as well that passes in all Python environments I am able to test (I don't have PyPy and certain Python 3 versions installed).