### PR TITLE
Improve error message for missing Coveralls token.

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -70,8 +70,10 @@ class Coveralls(object):
             self.config['repo_token'] = os.environ.get('COVERALLS_REPO_TOKEN')
 
         if token_required and not self.config.get('repo_token') and not is_travis_or_circle:
-            raise CoverallsException('You have to provide either repo_token in %s, or launch via Travis or CircleCI'
-                                     % self.config_filename)
+            raise CoverallsException(
+                'Not on Travis or CircleCI. You have to provide either repo_token in %s '
+                'or set the COVERALLS_REPO_TOKEN env var.' % self.config_filename
+            )
 
     def load_config(self):
         try:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -110,9 +110,8 @@ class NoConfig(unittest.TestCase):
     def test_misconfigured(self):
         with pytest.raises(Exception) as excinfo:
             Coveralls()
-
-        assert str(excinfo.value) == 'You have to provide either repo_token in .coveralls.mock, or launch via Travis ' \
-                                     'or CircleCI'
+        assert str(excinfo.value) == 'Not on Travis or CircleCI. You have to provide either repo_token in .coveralls.mock ' \
+                                     'or set the COVERALLS_REPO_TOKEN env var.'
 
     @patch.dict(os.environ, {'CIRCLECI': 'True',
                              'CIRCLE_BUILD_NUM': '888',

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -110,8 +110,8 @@ class NoConfig(unittest.TestCase):
     def test_misconfigured(self):
         with pytest.raises(Exception) as excinfo:
             Coveralls()
-        assert str(excinfo.value) == 'Not on Travis or CircleCI. You have to provide either repo_token in .coveralls.mock ' \
-                                     'or set the COVERALLS_REPO_TOKEN env var.'
+        assert str(excinfo.value) == 'Not on Travis or CircleCI. You have to provide either repo_token in .coveralls.mock or ' \
+                                     'set the COVERALLS_REPO_TOKEN env var.'
 
     @patch.dict(os.environ, {'CIRCLECI': 'True',
                              'CIRCLE_BUILD_NUM': '888',


### PR DESCRIPTION
Mentioning the alternative of setting an environment variable is more useful for CI contexts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coagulant/coveralls-python/111)
<!-- Reviewable:end -->
