### PR TITLE
Add Buildkite support

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -219,6 +219,7 @@ class Coveralls(object):
             },
             'branch': (os.environ.get('CIRCLE_BRANCH') or
                        os.environ.get('APPVEYOR_REPO_BRANCH') or
+                       os.environ.get('BUILDKITE_BRANCH') or
                        os.environ.get('CI_BRANCH') or
                        os.environ.get('TRAVIS_BRANCH', rev)),
             # origin	git@github.com:coagulant/coveralls-python.git (fetch)

--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -56,6 +56,10 @@ class Coveralls(object):
             self.config['service_job_id'] = os.environ.get('CIRCLE_BUILD_NUM')
             if os.environ.get('CI_PULL_REQUEST', None):
                 self.config['service_pull_request'] = os.environ.get('CI_PULL_REQUEST').split('/')[-1]
+        elif os.environ.get('BUILDKITE'):
+            is_travis_or_circle = False
+            self.config['service_name'] = file_config.get('service_name', None) or 'buildkite'
+            self.config['service_job_id'] = os.environ.get('BUILDKITE_JOB_ID')
         elif os.environ.get('APPVEYOR'):
             is_travis_or_circle = False
             self.config['service_name'] = file_config.get('service_name', None) or 'appveyor'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -132,6 +132,13 @@ class NoConfig(unittest.TestCase):
         assert cover.config['service_job_id'] == '1234567'
         assert cover.config['service_pull_request'] == '1234'
 
+    @patch.dict(os.environ, {'BUILDKITE': 'True',
+                             'BUILDKITE_JOB_ID': '1234567'}, clear=True)
+    def test_buildkite_no_config(self):
+        cover = Coveralls(repo_token='xxx')
+        assert cover.config['service_name'] == 'buildkite'
+        assert cover.config['service_job_id'] == '1234567'
+
 
 class Git(GitBasedTest):
 


### PR DESCRIPTION
This pull request adds support for the BuildKite CI system, allowing the library to pick up the BuildKite job ID, and the branch that it was built against.

Added a test for this also.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coagulant/coveralls-python/112)
<!-- Reviewable:end -->
