### PR TITLE
Fix Travis runtime versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,14 @@
 sudo: false
 language: python
 python:
-  - 2.6
   - 2.7
   - 3.3
   - 3.4
   - 3.5
-  - pypy
-  - pypy3
+  - pypy-5.4
+  - pypy3.3-5.2-alpha1
 env:
   matrix:
-    - $COVPYYAML=cov3-default,coveralls3
-    - $COVPYYAML=cov4-pyyaml,coveralls4
-    - $COVPYYAML=cov41-pyyaml,coveralls41
     - $COVPYYAML=cov3-default,coveralls3
     - $COVPYYAML=cov4-pyyaml,coveralls4
     - $COVPYYAML=cov41-pyyaml,coveralls41

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{26,27,33,34,35,py,py3}-cov{3,4,41}-{default,pyyaml}
+envlist = py{27,33,34,35,py,py3,py-54,py33-52-alpha1}-cov{3,4,41}-{default,pyyaml}
 
 [testenv]
 passenv = *


### PR DESCRIPTION
- Drop Python 2.6. Builds failed on Travis under 2.6 due to an
  InsecurePlatformWarning. SSL is insecure on vanilla Python
  versions before 2.7.9 as mentioned in [urllib3's docs][1].

- Replace pypy (2.5.0) with pypy-5.4. This was failing due to the
  same issue as python2.6. Pypy 2.5.0 is based on Python 2.7.8 in
  Travis, while Pypy 5.4.0 is based on Python 2.7.10.

- Replace pypy3 (2.4.0) with pypy3.3-5.2-alpha1. Failures here were
  related to incompatibility between setuptools and Python 3.2. See
  more details on [the related Travis issue][2].

[1]: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
[2]: https://github.com/travis-ci/travis-ci/issues/6277

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coagulant/coveralls-python/127)
<!-- Reviewable:end -->
